### PR TITLE
test: Run with relevant React stable types

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,6 +55,12 @@ jobs:
       - name: ⚛️ Setup react
         run: npm install react@${{ matrix.react }} react-dom@${{ matrix.react }}
 
+      - name: ⚛️ Setup react types
+        if: ${{ matrix.react != 'canary' && matrix.react != 'experimental' }}
+        run:
+          npm install @types/react@${{ matrix.react }} @types/react-dom@${{
+          matrix.react }}
+
       - name: ▶️ Run validate script
         run: npm run validate
 


### PR DESCRIPTION
This has no effect right now.
Once React 19 is out, we're running tests in both 18 and 19. The types should match that dimension.

Ideally, we'd be able to test RC types but npm claims `npm install @types/react@npm:types-react@rc` is an invalid comparator. Putting that in the package.json works but I'm too lazy to write a dedicated script right now.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the
      [docs site](https://github.com/testing-library/testing-library-docs)
- [ ] Tests
- [ ] TypeScript definitions updated
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
